### PR TITLE
[Dagger version upgrade][Removed HasActivityInjector] [Removed HasFragmentInjector ]

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,13 +8,12 @@ apply plugin: 'kotlin-android-extensions'
 
 project.ext {
     supportLibraryVersion = "28.0.0"
-    daggerVersion = "2.22.1"
+    daggerVersion = "2.24"
     butterKnifeVersion = "10.1.0"
 }
 
 android {
     compileSdkVersion 28
-    buildToolsVersion "28.0.3"
     defaultConfig {
         applicationId "com.jshvarts.daggerandroidmvp"
         minSdkVersion 19

--- a/app/src/main/kotlin/com/jshvarts/daggerandroidmvp/App.kt
+++ b/app/src/main/kotlin/com/jshvarts/daggerandroidmvp/App.kt
@@ -1,17 +1,17 @@
 package com.jshvarts.daggerandroidmvp
 
-import android.app.Activity
 import android.app.Application
 import com.jshvarts.daggerandroidmvp.di.DaggerAppComponent
 import dagger.android.AndroidInjector
-import dagger.android.HasActivityInjector
 import dagger.android.DispatchingAndroidInjector
+import dagger.android.HasAndroidInjector
 import javax.inject.Inject
 
 
-class App : Application(), HasActivityInjector {
+class App : Application(), HasAndroidInjector {
+
     @Inject
-    lateinit var activityInjector: DispatchingAndroidInjector<Activity>
+    lateinit var dispatchingAndroidInjector: DispatchingAndroidInjector<Any>
 
     override fun onCreate() {
         super.onCreate()
@@ -21,5 +21,7 @@ class App : Application(), HasActivityInjector {
                 .inject(this)
     }
 
-    override fun activityInjector(): AndroidInjector<Activity> = activityInjector
+    override fun androidInjector(): AndroidInjector<Any> {
+        return dispatchingAndroidInjector
+    }
 }

--- a/app/src/main/kotlin/com/jshvarts/daggerandroidmvp/lobby/LobbyActivity.kt
+++ b/app/src/main/kotlin/com/jshvarts/daggerandroidmvp/lobby/LobbyActivity.kt
@@ -4,20 +4,16 @@ import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import com.jshvarts.daggerandroidmvp.R
 import com.jshvarts.daggerandroidmvp.common.data.CommonHelloService
-import dagger.android.AndroidInjection
-import dagger.android.AndroidInjector
-import dagger.android.HasFragmentInjector
 import javax.inject.Inject
-import dagger.android.DispatchingAndroidInjector
 import android.widget.TextView
-import android.app.Fragment
 import butterknife.BindView
 import butterknife.ButterKnife
+import dagger.android.*
 
-class LobbyActivity : AppCompatActivity(), HasFragmentInjector {
+class LobbyActivity : AppCompatActivity(), HasAndroidInjector {
 
     @Inject
-    lateinit var fragmentDispatchingAndroidInjector: DispatchingAndroidInjector<Fragment>
+    lateinit var androidInjector: DispatchingAndroidInjector<Any>
 
     @Inject
     lateinit var commonHelloService: CommonHelloService
@@ -46,7 +42,9 @@ class LobbyActivity : AppCompatActivity(), HasFragmentInjector {
         //println("call to LobbyActivityHelloService: " + lobbyActivityHelloService.sayHello())
     }
 
-    override fun fragmentInjector(): AndroidInjector<Fragment> = fragmentDispatchingAndroidInjector
+    override fun androidInjector(): AndroidInjector<Any> {
+       return androidInjector
+    }
 
     private fun sayCommonHello() {
         commonHelloTextView.text = commonHelloService.sayHello()

--- a/app/src/main/kotlin/com/jshvarts/daggerandroidmvp/lobby/LobbyFragment.kt
+++ b/app/src/main/kotlin/com/jshvarts/daggerandroidmvp/lobby/LobbyFragment.kt
@@ -1,18 +1,18 @@
 package com.jshvarts.daggerandroidmvp.lobby
 
+import android.app.Fragment
 import android.content.Context
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import dagger.android.AndroidInjection
-import javax.inject.Inject
 import android.widget.TextView
-import android.app.Fragment
 import butterknife.BindView
 import butterknife.ButterKnife
-import com.jshvarts.daggerandroidmvp.R
 import butterknife.Unbinder
+import com.jshvarts.daggerandroidmvp.R
+import dagger.android.AndroidInjection
+import javax.inject.Inject
 
 class LobbyFragment : Fragment() {
 
@@ -24,22 +24,23 @@ class LobbyFragment : Fragment() {
 
     private lateinit var unbinder: Unbinder
 
+    override fun onAttach(context: Context) {
+        AndroidInjection.inject(this)
+        super.onAttach(context)
+    }
+
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         val view = inflater.inflate(R.layout.lobby_fragment, container, false)
         unbinder = ButterKnife.bind(this, view)
         return view
     }
 
-    override fun onViewCreated(view: View?, savedInstanceState: Bundle?) {
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
         sayFragmentHello()
     }
 
-    override fun onAttach(context: Context?) {
-        AndroidInjection.inject(this)
-        super.onAttach(context)
-    }
 
     override fun onDestroyView() {
         super.onDestroyView()

--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,14 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.3.21'
+    ext.kotlin_version = '1.3.31'
     repositories {
         google()
         jcenter()
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.0'
+        classpath 'com.android.tools.build:gradle:3.4.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong


### PR DESCRIPTION
1. Upgraded to latest Dagger Version.
2. Removed `HasActivityInjector` and `HasFragmentInjector` because it is not present in this version of Dagger so it was giving an error because of the same and replaced it with `HasAndroidInjector`.
3. Removed `buildToolsVersion` :  With the new android gradle plugin 3.x, we no longer need to specify a version for the build tools. By default, the plugin automatically uses the minimum required build tools version for the version of Android plugin you're using.
4. Increased `kotlin_version`.

> Todo: Find a way to replace `android.app.Fragment` with `androidx.fragment.app.Fragment` currently it as giving an error as `AndroidInjection`  does not support `AndroidX` fragment.